### PR TITLE
fix(temp_directory): set temp_directory to /tmp

### DIFF
--- a/bootstrap.cpp
+++ b/bootstrap.cpp
@@ -110,7 +110,7 @@ int main()
   // is probably not ideal in the spirit of single execution isolation.
   DuckDB db(nullptr);
   Connection con(db);
-  auto result = con.Query("SET home_directory='/tmp'; SET extension_directory='/opt/duckdb_extensions';");
+  auto result = con.Query("SET home_directory='/tmp'; SET extension_directory='/opt/duckdb_extensions'; SET temp_directory='/tmp';");
   if (result->HasError())
   {
     cerr << "Failed to set home directory: " << result->GetError() << endl;


### PR DESCRIPTION
Fix for errors such as 
```
{
  "errorMessage": "IO Error: Failed to create directory \".tmp\": Read-only file system",
  "errorType": "QueryError",
}
```